### PR TITLE
New test endpoint tested and removed

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -48,11 +48,6 @@ async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
 
 
-@router.get("/status", status_code=status.HTTP_200_OK)
-async def get_book() -> str:
-    return "Active"
-
-
 #Missing Implementation
 @router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def get_book(book_id: int) -> Book:


### PR DESCRIPTION
## Description
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.
- Configured Nginx reverse proxy for FastAPI.

## Related Task
[HNG12 Stage 2 Task](#task-description-link)

## Testing
- Ran `pytest` locally (all tests passed).
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.

## Notes
- Invited `hng12-devbotops` as a collaborator.
- Deployment URL: `http://102.37.155.61`
